### PR TITLE
Bump diffusers to 0.7.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,6 @@ pytest
 yacs
 markupsafe==2.0.1
 scikit-image==0.19.3
-diffusers==0.6.0
+diffusers==0.7.2
 transformers==4.21.0
+accelerate==0.14.0


### PR DESCRIPTION
Bump diffusers version and add required `accelerate` dependency. This version reduces model load time and introduces [long prompt weighting stable diffusion](https://github.com/huggingface/diffusers/tree/main/examples/community#long-prompt-weighting-stable-diffusion) for free with no code changes!

This version also allows for future optimizations by using [memory_efficient_attention](https://github.com/huggingface/diffusers/pull/532), as well as adding an unconditional inpainting algorithm called [RePaint](https://huggingface.co/docs/diffusers/api/pipelines/repaint) and Mac M1/M2 mps support.