### PR TITLE
Add argument for enabling xFormers optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Available command line arguments:
 | --sd-run-local       | Once the model as downloaded, you can pass this arg and remove `--hf_access_token`                                  |          |
 | --sd-disable-nsfw    | Disable stable-diffusion NSFW checker.                                                                              |          |
 | --sd-cpu-textencoder | Always run stable-diffusion TextEncoder model on CPU.                                                               |          |
+| --sd-enable-xformers | Enable xFormers optimizations. See: [facebookresearch/xformers](https://github.com/facebookresearch/xformers)       |          |
 | --device             | cuda or cpu                                                                                                         | cuda     |
 | --port               | Port for backend flask web server                                                                                   | 8080     |
 | --gui                | Launch lama-cleaner as a desktop application                                                                        |          |

--- a/lama_cleaner/model/sd.py
+++ b/lama_cleaner/model/sd.py
@@ -71,8 +71,11 @@ class SD(InpaintModel):
             use_auth_token=kwargs["hf_access_token"],
             **model_kwargs
         )
-        # https://huggingface.co/docs/diffusers/v0.3.0/en/api/pipelines/stable_diffusion#diffusers.StableDiffusionInpaintPipeline.enable_attention_slicing
+        # https://huggingface.co/docs/diffusers/v0.7.0/en/api/pipelines/stable_diffusion#diffusers.StableDiffusionInpaintPipeline.enable_attention_slicing
         self.model.enable_attention_slicing()
+        # https://huggingface.co/docs/diffusers/v0.7.0/en/optimization/fp16#memory-efficient-attention
+        if kwargs['sd_enable_xformers']:
+            self.model.enable_xformers_memory_efficient_attention()
         self.model = self.model.to(device)
 
         if kwargs['sd_cpu_textencoder']:

--- a/lama_cleaner/parse_args.py
+++ b/lama_cleaner/parse_args.py
@@ -32,6 +32,11 @@ def parse_args():
         action="store_true",
         help="After first time Stable Diffusion model downloaded, you can add this arg and remove --hf_access_token",
     )
+    parser.add_argument(
+        "--sd-enable-xformers",
+        action="store_true",
+        help="Enable xFormers optimizations. Requires that xformers package has been installed. See: https://github.com/facebookresearch/xformers"
+    )
     parser.add_argument("--device", default="cuda", type=str, choices=["cuda", "cpu"])
     parser.add_argument("--gui", action="store_true", help="Launch as desktop app")
     parser.add_argument(

--- a/lama_cleaner/server.py
+++ b/lama_cleaner/server.py
@@ -256,6 +256,7 @@ def main(args):
         sd_disable_nsfw=args.sd_disable_nsfw,
         sd_cpu_textencoder=args.sd_cpu_textencoder,
         sd_run_local=args.sd_run_local,
+        sd_enable_xformers=args.sd_enable_xformers,
         callback=diffuser_callback,
     )
 


### PR DESCRIPTION
This change allows users to take advantage of the speed and memory optimizations provided by [xFormers](https://github.com/facebookresearch/xformers). Since this package is currently not published with binaries for all platforms (like Windows) I didn't add it to `requirements.txt` but rather made it an optional install for now.

`enable_xformers_memory_efficient_attention()` gives a big boost in speed while also reducing GPU memory usage significantly. A 512x512 test I did cut the processing time almost in half: 

Without xFormers:
```
2022-11-28 17:29:56.669 | INFO     | lama_cleaner.model.base:_pad_forward:54 - final forward pad size: (512, 512, 3)
100%|██████████████████████████████████████████████████████████████████████████████████| 51/51 [00:12<00:00,  4.16it/s]
2022-11-28 17:30:12.514 | INFO     | lama_cleaner.server:process:164 - process time: 15846.312522888184ms
```
With xFormers:
```
2022-11-28 17:30:48.092 | INFO     | lama_cleaner.model.base:_pad_forward:54 - final forward pad size: (512, 512, 3)
100%|██████████████████████████████████████████████████████████████████████████████████| 51/51 [00:05<00:00,  8.70it/s]
2022-11-28 17:30:57.286 | INFO     | lama_cleaner.server:process:164 - process time: 9196.5172290802ms
```