### PR TITLE
Fixed boxes_from_mask avoiding tiny boxes

### DIFF
--- a/lama_cleaner/helper.py
+++ b/lama_cleaner/helper.py
@@ -77,7 +77,8 @@ def numpy_to_bytes(image_numpy: np.ndarray, ext: str) -> bytes:
     data = cv2.imencode(
         f".{ext}",
         image_numpy,
-        [int(cv2.IMWRITE_JPEG_QUALITY), 100, int(cv2.IMWRITE_PNG_COMPRESSION), 0],
+        [int(cv2.IMWRITE_JPEG_QUALITY), 100, int(
+            cv2.IMWRITE_PNG_COMPRESSION), 0],
     )[1]
     image_bytes = data.tobytes()
     return image_bytes
@@ -158,7 +159,7 @@ def pad_img_to_modulo(
     )
 
 
-def boxes_from_mask(mask: np.ndarray) -> List[np.ndarray]:
+def boxes_from_mask(mask: np.ndarray, min_area: float = 0.02) -> List[np.ndarray]:
     """
     Args:
         mask: (h, w, 1)  0~255
@@ -168,7 +169,10 @@ def boxes_from_mask(mask: np.ndarray) -> List[np.ndarray]:
     """
     height, width = mask.shape[:2]
     _, thresh = cv2.threshold(mask, 127, 255, 0)
-    contours, _ = cv2.findContours(thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    contours, _ = cv2.findContours(
+        thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    contours = [c for c in contours if cv2.contourArea(
+        c) > height*width*min_area]
 
     boxes = []
     for cnt in contours:


### PR DESCRIPTION
This PR tries to avoid the situation where the threshold or the mask have tiny dots or tiny contours (I had instances with some images where there are 200 or more boxes found but only 1 was relevant).

This makes the algorithm really slow and doesn't provide a good result.

I am using the contour area as a discriminant.