### PR TITLE
Clear model from memory before switch, fixes out of memory

### DIFF
--- a/lama_cleaner/model_manager.py
+++ b/lama_cleaner/model_manager.py
@@ -1,4 +1,5 @@
 import torch
+import gc
 
 from lama_cleaner.model.fcf import FcF
 from lama_cleaner.model.lama import LaMa
@@ -42,6 +43,12 @@ class ModelManager:
         if new_name == self.name:
             return
         try:
+            if (torch.cuda.memory_allocated() > 0):
+                # Clear current loaded model from memory
+                torch.cuda.empty_cache()
+                gc.collect()
+                del self.model
+
             self.model = self.init_model(new_name, self.device, **self.kwargs)
             self.name = new_name
         except NotImplementedError as e:

--- a/lama_cleaner/model_manager.py
+++ b/lama_cleaner/model_manager.py
@@ -46,8 +46,8 @@ class ModelManager:
             if (torch.cuda.memory_allocated() > 0):
                 # Clear current loaded model from memory
                 torch.cuda.empty_cache()
-                gc.collect()
                 del self.model
+                gc.collect()
 
             self.model = self.init_model(new_name, self.device, **self.kwargs)
             self.name = new_name


### PR DESCRIPTION
When trying to change model from sd1.5 to sd2 a torch "out of memory" error appeared in the console.

Function [switch()](https://github.com/Sanster/lama-cleaner/blob/main/lama_cleaner/model_manager.py#L41) from model_manager.py was not clearing current loaded model before loading new one, causing a lot of memory usage. In systems with 4GB (RTX 3050 Laptop) was not able to handle it.

We can check if memory is been used by torch, so we clean the model and call garbage collector
```
if (torch.cuda.memory_allocated() > 0):
    # Clear current loaded model from memory
    torch.cuda.empty_cache()
    del self.model
    gc.collect()
```