### PR TITLE
fix(sec): upgrade torch to 1.13.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch>=1.9.0
+torch>=1.13.1
 opencv-python
 flask==2.2.3
 flask-socketio


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in torch 1.9.0
- [CVE-2022-45907](https://www.oscs1024.com/hd/CVE-2022-45907)


### What did I do？
Upgrade torch from 1.9.0 to 1.13.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS