### PR TITLE
[Fix] Specify werkzeug version and modify readme(quick start)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ Lama Cleaner make it easy to use SOTA AI model in just two commands:
 ```bash
 # In order to use the GPU, install cuda version of pytorch first.
 # pip install torch==1.13.1+cu117 torchvision==0.14.1 --extra-index-url https://download.pytorch.org/whl/cu117
-pip install lama-cleaner
-lama-cleaner --model=lama --device=cpu --port=8080
+git clone https://github.com/Sanster/lama-cleaner.git
+cd lama-cleaner
+python main.py
 ```
 
 That's it, Lama Cleaner is now running at http://localhost:8080

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ piexif==1.1.3
 safetensors
 omegaconf
 controlnet-aux==0.0.3
+werkzeug==2.2.2


### PR DESCRIPTION
Recently, the version of `werkzeug` has been updated, causing a problem that the code cannot execute. 

The problem was solved by specifying the version of `werkzeug` in the Requirements.txt.

However, since I tested the modified code through `python main.py`, I also modified the Readme file. This should be changed back to the pip install format later.
