### PR TITLE
Fixes install error on Windows due to slash in path in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/Sanster/lama-cleaner",
-    packages=setuptools.find_packages("./"),
+    packages=setuptools.find_packages("."),
     package_data={"lama_cleaner": web_files},
     install_requires=load_requirements(),
     python_requires=">=3.7",


### PR DESCRIPTION
`pip install` command fails on Windows due to trailing slash in setup.py

I'm just submitting in Draft mode, as someone else will need to validate this doesn't break other OS installers that are supported.  I looked at other PR and don't see a CI to automate this?  

Validation can just be a `pip install -e .` or such on different OS.  I tested on Windows 11, Python 3.11.7.  

